### PR TITLE
Support push to branch for multibranch

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -39,6 +39,9 @@ if [ -z "$uri" ]; then
 fi
 
 if [ -z "$branch" ]; then
+  branch=$(git -C $repository config --local concourse-ci.branch-name)
+fi
+if [ -z "$branch" ]; then
   echo "invalid payload (missing branch)"
   exit 1
 fi

--- a/assets/out
+++ b/assets/out
@@ -38,6 +38,8 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
+cd $source
+
 if [ -z "$branch" ]; then
   branch=$(git -C $repository config --local concourse-ci.branch-name)
 fi
@@ -50,8 +52,6 @@ if [ -z "$repository" ]; then
   echo "invalid payload (missing repository)"
   exit 1
 fi
-
-cd $source
 
 if [ -n "$tag" ] && [ ! -f "$tag" ]; then
   echo "tag file '$tag' does not exist"
@@ -128,6 +128,6 @@ else
 fi
 
 jq -n "{
-  version: {ref: $(git rev-parse HEAD | jq -R .)},
+  version: {ref: $(echo $(git rev-parse HEAD):$branch | jq -R .)},
   metadata: $(git_metadata)
 }" >&3

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -446,3 +446,16 @@ put_uri_with_rebase_with_tag_and_prefix() {
     }
   }" | ${resource_dir}/out "$2" | tee /dev/stderr
 }
+
+put_uri_with_multibranch() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branches: $(echo $4 | jq -R .)
+    },
+    params: {
+      repository: $(echo $3 | jq -R .),
+      multibranch: true
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}

--- a/test/put.sh
+++ b/test/put.sh
@@ -20,7 +20,7 @@ it_can_put_to_url() {
   git -C $repo1 checkout refs/heads/master
 
   put_uri $repo1 $src repo | jq -e "
-    .version == {ref: $(echo $ref | jq -R .)}
+    .version == {ref: $(echo $ref:master | jq -R .)}
   "
 
   # switch back to master
@@ -46,7 +46,7 @@ it_can_put_to_url_with_tag() {
   git -C $repo1 checkout refs/heads/master
 
   put_uri_with_tag $repo1 $src some-tag-file repo | jq -e "
-    .version == {ref: $(echo $ref | jq -R .)}
+    .version == {ref: $(echo $ref:master | jq -R .)}
   "
 
   # switch back to master
@@ -72,7 +72,7 @@ it_can_put_to_url_with_tag_and_prefix() {
   git -C $repo1 checkout refs/heads/master
 
   put_uri_with_tag_and_prefix $repo1 $src some-tag-file v repo | jq -e "
-    .version == {ref: $(echo $ref | jq -R .)}
+    .version == {ref: $(echo $ref:master | jq -R .)}
   "
 
   # switch back to master
@@ -105,7 +105,7 @@ it_can_put_to_url_with_rebase() {
   local rebased_ref=$(git -C $repo2 rev-parse HEAD)
 
   jq -e "
-    .version == {ref: $(echo $rebased_ref | jq -R .)}
+    .version == {ref: $(echo $rebased_ref:master | jq -R .)}
   " < $response
 
   # switch back to master
@@ -139,7 +139,7 @@ it_can_put_to_url_with_rebase_with_tag() {
   local rebased_ref=$(git -C $repo2 rev-parse HEAD)
 
   jq -e "
-    .version == {ref: $(echo $rebased_ref | jq -R .)}
+    .version == {ref: $(echo $rebased_ref:master | jq -R .)}
   " < $response
 
   # switch back to master
@@ -174,7 +174,7 @@ it_can_put_to_url_with_rebase_with_tag_and_prefix() {
   local rebased_ref=$(git -C $repo2 rev-parse HEAD)
 
   jq -e "
-    .version == {ref: $(echo $rebased_ref | jq -R .)}
+    .version == {ref: $(echo $rebased_ref:master | jq -R .)}
   " < $response
 
   # switch back to master
@@ -201,7 +201,7 @@ it_can_put_to_url_with_only_tag() {
   git -C $repo1 checkout refs/heads/master
 
   put_uri_with_only_tag $repo1 $src repo | jq -e "
-    .version == {ref: $(echo $ref | jq -R .)}
+    .version == {ref: $(echo $ref:master | jq -R .)}
   "
 
   # switch back to master
@@ -232,7 +232,7 @@ it_can_put_to_url_when_multibranch() {
   test "$(git -C $dest rev-parse branch-a)" = $ref3
 
   put_uri_with_multibranch $repo $repo $dest "(branch-a)" | jq -e "
-    .version == {ref: $(echo "$ref3" | jq -R .)}
+    .version == {ref: $(echo $ref3:branch-a | jq -R .)}
   "
 
   git -C $repo checkout branch-a


### PR DESCRIPTION
This PR adds support for `put` if multibranches are used (ie if the the `branch` param is not given). The push happens to the branch that was checked out, it uses the (existing) git config setting to find the correct branch.

I had to change the returned json by `out`: I needed to add `:<branchname>` to the version and am not sure what the side-effects of this are.