### PR TITLE
Add git-lfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM alpine:3.12.0
 
 ENV LANG C
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12.0
 
 ENV LANG C
 
-RUN apk add --no-cache curl bash git redis jq openssh perl
+RUN apk add --no-cache curl bash git git-lfs redis jq openssh perl
 
 RUN git config --global user.name "Concourse CI GIT Resource" \
  && git config --global user.email "git.concourse-ci@localhost"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Submodules are initialized and updated recursively.
   fetched. If not specified, or if `all` is explicitly specified, all
   submodules are fetched.
 
+* `disable_git_lfs`: _Optional._ Disable Git LFS, skipping an attempt to
+  convert pointers of files tracked into their corresponding objects when
+  checked out into a working copy.
 
 ### `out`: Push to a repository.
 

--- a/assets/in
+++ b/assets/in
@@ -31,6 +31,7 @@ ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
+disable_git_lfs=$(jq -r '.params.disable_git_lfs // ""' < $payload)
 
 ## Redis stuff to support cleaner multibranch wait-for-previous behaviour
 redis_host=$(jq -r '.source.redis.host // ""' < $payload)
@@ -74,6 +75,11 @@ depthflag=""
 if test "$depth" -gt 0 2> /dev/null
 then
   depthflag="--depth $depth"
+fi
+
+if [ "$disable_git_lfs" == "true" ]
+then
+  export GIT_LFS_SKIP_SMUDGE="true"
 fi
 
 echo "Cloning: git clone ${single_branch_flag}$depthflag $uri $branchflag $destination"

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -71,6 +71,7 @@ make_commit_to_file_on_branch() {
   local file=$2
   local branch=$3
   local msg=${4-}
+  local file_contents=${5-x}
 
   # ensure branch exists
   if ! git -C $repo rev-parse --verify $branch >/dev/null 2>&1; then
@@ -81,7 +82,7 @@ make_commit_to_file_on_branch() {
   git -C $repo checkout -q $branch
 
   # modify file and commit
-  echo x >> $repo/$file
+  echo $file_contents >> $repo/$file
   git -C $repo add $file
   git -C $repo \
     -c user.name='test' \
@@ -94,6 +95,10 @@ make_commit_to_file_on_branch() {
 
 make_commit_to_file() {
   make_commit_to_file_on_branch $1 $2 master "${3-}"
+}
+
+make_commit_to_file_with_contents() {
+  make_commit_to_file_on_branch $1 $2 master "${3-}" "${4}"
 }
 
 make_commit_to_branch() {
@@ -289,6 +294,14 @@ test_get() {
               host: $(echo "localhost" | jq -R '.'),
               prefix: $(echo "$1" | jq -R '.')
             }
+          }
+        }")"
+        shift;;
+
+      "disable_git_lfs" )
+        addition="$(jq -n "{
+          params: {
+            disable_git_lfs: $(echo "$1" | jq -R .)
           }
         }")"
         shift;;


### PR DESCRIPTION
Adds git-lfs support fitting with the configuration options and style of [`git-resource`](https://github.com/concourse/git-resource). Resolves issue #14.

Added tests to verify behaviour which are passing. 

Once slightly unrelated change here is that I updated the version of alpine the project uses as using `apk add` to install `git-lfs` wasn't working on the previous version in use. I felt upgrading was the path of least resistance. Also gave an opportunity to move over to using the official `alpine` Docker Hub image name.